### PR TITLE
Hacks to is_Digit function, and divisibility logic

### DIFF
--- a/Evaluate_Reverse_Polish_Notation.py
+++ b/Evaluate_Reverse_Polish_Notation.py
@@ -11,22 +11,51 @@ class Solution:
         if operator == "*":
             result = first_digit * second_digit
         if operator == "/":
+            # this section is hacky. We need to check if the absolute values 
+            # are acceptable for integer division in order to get the desired output.
+            # e.g. 6/-132 wouldn't return 0. It would return -1 using integer division (//). 
+
+            if abs(first_digit) < abs(second_digit): return 0
             result = first_digit // second_digit
         return result
 
+    #the python isdigit function is not recognizing negative numbers so I'm tweaking the function. 
+    def is_digit(self, digit:str):
+        try:
+            int(digit)
+            return True
+        except ValueError:
+            return False
+
     def evalRPN(self, tokens: List[str]) -> int:
+        if len(tokens) == 1: return int(tokens[0])
         #integer stack
         operands = []
         #operators = []
 
         for value in tokens:
-            
-            if value.isdigit():
+            #this is digit function is not accounting for the negative -11
+            if self.is_digit(value):
+
                 operands.append(int(value))
+
             else:
+                print("operator ", value)
                 print(operands)
                 second_digit = operands.pop()
+                print("second_digit",second_digit)
                 first_digit = operands.pop()
+                print("first_digit",first_digit)
+
+                result = self.operatorHelper(value, first_digit, second_digit)
+                operands.append(result)
+                print(operands)
+
+        result = operands.pop()
+        return result
+
+           
+
                 result = self.operatorHelper(value, first_digit, second_digit)
                 operands.append(result)
                 print(operands)


### PR DESCRIPTION
*Warning. This version does not pass leetcode submit. See below. *

Python's is digit funciton does not recognize negative numbers. The remeby to this was to use  try/except logic to try to cast any input to an int, and except ValueErrors which will alert you that the value is not a digit.

I used the absolute value function to compare inputs for division. More info is in the comments.

*Failing input : ["-78","-33","196","+","-19","-","115","+","-","-99","/","-18","8","*","-86","-","-","16","/","26","-14","-","-","47","-","101","-","163","*","143","-","0","-","171","+","120","*","-60","+","156","/","173","/","-24","11","+","21","/","*","44","*","180","70","-40","-","*","86","132","-84","+","*","-","38","/","/","21","28","/","+","83","/","-31","156","-","+","28","/","95","-","120","+","8","*","90","-","-94","*","-73","/","-62","/","93","*","196","-","-59","+","187","-","143","/","-79","-89","+","-"] *